### PR TITLE
Add .gitattributes to avoid archiving source code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src export-ignore


### PR DESCRIPTION
Source code is currently included in releases by default. This flag will disable this functionality.